### PR TITLE
Fixed activation and pwd recovery token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 un projet pour faire du passport js
 
 Configurer l'envoi de mails, éditer le fichier config/mailer.js et mettre les bonnes informations
+
+
+Comme le projet inclus des fichiers avec des infos sensibles ( app id et secret, mdp mail ...) petit rappel de commandes git utiles :
+* pour ne plus suivre les évolutions d'un fichier ( ne pas risquer de pousser son fichier de config/auth.js par exemple )
+git update-index --skip-worktree config/auth.js
+
+* pour lister les fichiers que l'on ne suit plus :
+git ls-files -v . | grep ^S
+
+* pour se remettre à suivre un fichier ( pas exemple le config/auth.js parce que le repo distant l'a update)
+git update-index --no-skip-worktree config/auth.js

--- a/application/routes.js
+++ b/application/routes.js
@@ -145,9 +145,10 @@ module.exports = function(app, passport) {
                             {
                                 to : email,
                                 subject : "iauthenticate pwd recovery ok",
-                                text : "you seem to have lost your pwd. "
+                                html : "you seem to have lost your pwd. "
                                  + "Click on the following link to change your password : " 
-                                 + "http://localhost:8080/pwdrecovery?token=" + user.local.pwdrecotoken
+                                 + "<a href=\"http://localhost:8080/pwdrecovery?token=" + user.local.pwdrecotoken
+                                 + "\">Password change</a>"
                             }
                             smtpTransport.sendMail(mailOptions, function(error, response){
                                 if(error)

--- a/config/auth.js
+++ b/config/auth.js
@@ -4,6 +4,7 @@
 // expose our config directly to our application using module.exports
 module.exports = {
 
+    'sessionsecret' : 'natoineiauthenticatesessionpassport', //passport needs this for sessions
     'facebookAuth' : {
         'clientID'      : '', // your App ID
         'clientSecret'  : '', // your App Secret
@@ -19,7 +20,7 @@ module.exports = {
     'googleAuth' : {
         'clientID'      : '',
         'clientSecret'  : '',
-        'callbackURL'   : 'http://127.0.0.1:8080/auth/google/callback'
+        'callbackURL'   : 'http://localhost:8080/auth/google/callback'
     }
 
 }

--- a/config/mailer.js
+++ b/config/mailer.js
@@ -6,8 +6,8 @@ const smtpTransport = nodemailer.createTransport({
 	    service: "gmail",
 	    host: "smtp.gmail.com",
 	    auth: {
-	        user: "YOURUSERNAME",
-	        pass: "YOURPWD"
+	        user: "",
+	        pass: ""
 	    }
 	})
 

--- a/config/passport.js
+++ b/config/passport.js
@@ -86,7 +86,7 @@ module.exports = function(passport)
                         {
                             to : email,
                             subject : "iauthenticate account activation",
-                            text : "Welcome on iauthenticate. Please click the link bellow to activate your account : http://localhost:8080/activateaccount?email=" + email + "&token=" + newUser.local.activationtoken
+                            html : "Welcome on iauthenticate. Please click the link bellow to activate your account : <a href=\"http://localhost:8080/activateaccount?email=" + email + "&token=" + newUser.local.activationtoken +"\">Activate Account</a>"
                         }
                         smtpTransport.sendMail(mailOptions, function(error, response){
                             if(error)

--- a/server.js
+++ b/server.js
@@ -15,10 +15,9 @@ const bodyParser   = require('body-parser') // deprecated
 const session      = require('express-session')
 
 const configDB = require('./config/database.js')
+const confsecret = require('./config/auth.js').sessionsecret
 
 // configuration ===============================================================
-//mongoose.connect("mongodb://localhost/iauthenticate") // works but deprecated
-//mongoose.connect(configDB.url) // connect to our database
 const db = mongoose.createConnection(configDB.url)
 
 require('./config/passport')(passport)
@@ -32,7 +31,7 @@ app.use(bodyParser()) // get information from html forms
 app.set('view engine', 'ejs') // set up ejs for templating
 
 // required for passport
-app.use(session({ secret: 'ilovescotchscotchyscotchscotch' })) // session secret, should be in config
+app.use(session({ secret: confsecret })) // session secret
 app.use(passport.initialize())
 app.use(passport.session()) // persistent login sessions
 app.use(flash()) // use connect-flash for flash messages stored in session


### PR DESCRIPTION
There was an error in generated emails for activation and pwd reco if the generated token finishes with a "." 
Now emails have html content and not plain texte anymore.